### PR TITLE
fix: suppression de l'appel configRL lorsque inutile

### DIFF
--- a/conf/local.protected.php
+++ b/conf/local.protected.php
@@ -1,19 +1,33 @@
 <?php
-define('RL_ROOT', dirname(__FILE__).'../../');
-include RL_ROOT.'../configRL.php';
-define('PUN_ROOT', dirname(__FILE__).'/../../'.folder_forum.'/');
-include PUN_ROOT.'include/common.php';
-define('RL_STYLE', $pun_user['style']);						# On appel de Style du profil FLUXBB
 
-$conf['useacl'] = 1;
-$conf['superuser'] = '@Administrateurs';
-$conf['authtype'] = 'authfluxbb';
-$conf['disableactions'] = 'register,resendpwd,profile,login,logout';
+$PunConfUseless = array(
 
-// Config Forum utilisées dans le menu gauche
-$conf['pun_style'] = $pun_user['style'];
-$conf['group_id'] = $pun_user['group_id'];
-$conf['id'] = $pun_user['id'];
+	'js.php',
+	'jquery.php',
+	'fetch.php',
+	'feed.php',
+
+);
+
+if ( ! in_array( basename($_SERVER['PHP_SELF']), $PunConfUseless ) ) {
+
+	define('RL_ROOT', dirname(__FILE__).'../../');
+	include RL_ROOT.'../configRL.php';
+	define('PUN_ROOT', dirname(__FILE__).'/../../'.folder_forum.'/');
+	include PUN_ROOT.'include/common.php';
+	define('RL_STYLE', $pun_user['style']);						# On appel de Style du profil FLUXBB
+
+	$conf['useacl'] = 1;
+	$conf['superuser'] = '@Administrateurs';
+	$conf['authtype'] = 'authfluxbb';
+	$conf['disableactions'] = 'register,resendpwd,profile,login,logout';
+
+	// Config Forum utilisées dans le menu gauche
+	$conf['pun_style'] = $pun_user['style'];
+	$conf['group_id'] = $pun_user['group_id'];
+	$conf['id'] = $pun_user['id'];
+
+}
 
 // Redirection temporaire si forum en maintenance
 // if ($pun_config['o_maintenance'] == '1' &&  $pun_user['group_id'] != 1) {


### PR DESCRIPTION
fetch.php notamment.
L'include de configRL.php sur ces pages générait de nombreux appels bdd inutiles, des erreurs 500 et des images en 404.